### PR TITLE
Kepp empty media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,8 @@ node_modules
 .sass-cache
 
 # User-uploaded media
-media/*
+**/media/*
+!**/media/.gitkeep
 
 # Collected staticfiles
 */staticfiles/


### PR DESCRIPTION
Use ** wildcard to match any level subdirectories.
Git does not track empty directory, so create .gitkeep
and exclude it.