### PR TITLE
modify caselist ui & not display title if no content

### DIFF
--- a/frontend/src/components/CaseList.vue
+++ b/frontend/src/components/CaseList.vue
@@ -13,26 +13,24 @@ el-container.page2
             .case-content-type-body 案件類別：{{selectedCaseDetails.type}}
             .case-content-title 案件標題：{{selectedCaseDetails.title}}
             .case-content-date 時間：{{selectedCaseDetails.create_time.split('-')[0]}} 年 {{selectedCaseDetails.create_time.split('-')[1]}} 月 {{selectedCaseDetails.create_time.split('-')[2]}} 日
-            .case-content-location 地點：{{selectedCaseDetails.location}}
+            .case-content-location(v-if="selectedCaseDetails.location !== null") 地點：{{selectedCaseDetails.location}}
             hr
             .case-content-details 案件內容：
             br
-            div(v-html="selectedCaseDetails.content") {{selectedCaseDetails.content}}
+            div(v-html="selectedCaseDetails.content")
             hr
-            div(v-if="selectedCaseDetails.state === '不受理'")
+            div(v-if="selectedCaseDetails.state === '不受理' && selectedCaseDetails.disapprove_info !== ''")
               .case-disapproved 案件不受理原因：
+              br
               .disapprove-info {{selectedCaseDetails.disapprove_info}}
-            div(v-if="selectedCaseDetails.state !== '不受理'")
+            div(v-if="selectedCaseDetails.state !== '不受理' && selectedCaseDetails.arranges.length !== 0")
               .arranges-title 案件處理進度：
+              br
               .case-content-arranges(v-for="arrange,index in reverseCaseProcess")
-                //- h4 處理回報（{{ reverseCaseProcess.length - index}}）
-                br
                 div.arrange-title 處理主旨： {{ arrange.title }}
                 div.arrange-time 處理時間： {{arrange.arrange_time}}
-                div.arrange-content(v-html="arrange.content") {{ arrange.content }}
+                div.arrange-content(v-html="arrange.content")
                 hr
-              br
-              br
             div(style="text-align: center; display:block") ---------- End ----------
           .dialog-footer(slot='footer')
             .footer-block
@@ -56,27 +54,16 @@ export default {
       selectedRow: null,
       mounted: false,
       selectedCaseDetails: {
-        'id': 1,
-        'number': '000001',
-        'create_time': '2019-01-02',
-        'title': '上班時段計程車過多',
-        'content': '小弟我是台北市民，常常看到很多路上的小黃為了載客硬切慢車道差點造成意外，到了深夜路上的小黃更是快比自用車還多，請問大家會不會覺得台北市的計程車太多了呀？',
-        'location': '台北市松山區復興北路',
+        'id': 13,
+        'number': '000013',
+        'create_time': '2019-02-19',
+        'title': '台北101周邊交通亂象',
+        'content': '由（松廉路松智路口周邊）到（松智路）到（信義路五段）到（市府路），這段路，有很多計程車違規排班停等、自小客違規臨停、大客車併排停等上下客（加上計程車違規搗蛋，有時候一併就四排），車流常因上述違規打結，公車因上述違規無法停靠站，公車乘客因上述違規無法安全上下車等。\r\n\r\n松智路（世貿三館往101方向）本身就不寬，一排要違停，一排要左轉松廉路，就只剩中間車道可以行車，車流交織甚為嚴重。\r\n\r\n松廉路松智路口周邊也不時看到車輛因為車流交織而發生擦撞，已與市政單一陳情搞了好一陣子，行政單位都沒有打算認真看待此處的亂象。',
+        'location': '由松廉路松智路口周邊 到（松智路）到（信義路五段）到市府路',
         'type': '交通運輸',
-        'state': '已完結',
-        'arranges': [
-          {
-            'title': '發文交通部1',
-            'content': '<p>面對UBER競爭，計程車司機的日子是越來越難過？<img src="https://i.pinimg.com/564x/a8/ec/82/a8ec828bbda82c7793e49e90aebcb5d1.jpg">交通部每2年進行1次計程車營運狀況調查近日公佈，去年專職計程車駕駛每月平均收入為4萬6045元，較104減少1583元；但營業支出卻微幅增加266元。交通部表示，UBER於102年就進入台灣，104年專職計程車駕駛收入有成長2333元，這個統計數字無法呈現是否是受UBER競爭所致，且抽樣統計時約有3%誤差，相差千餘元不一定代表駕駛所得真的下跌</p>',
-            'arrange_time': '2018-01-10'
-          },
-          {
-            'title': '發文交通部2',
-            'content': '<p>面對UBER競爭，計程車司機的日子是越來越難過？交通部每2年進行1次計程車營運狀況調查近日公佈，去年專職計程車駕駛每月平均收入為4萬6045元，較104減少1583元；但營業支出卻微幅增加266元。交通部表示，UBER於102年就進入台灣，104年專職計程車駕駛收入有成長2333元，這個統計數字無法呈現是否是受UBER競爭所致，且抽樣統計時約有3%誤差，相差千餘元不一定代表駕駛所得真的下跌</p>',
-            'arrange_time': '2018-01-12'
-          }
-        ],
-        'disapprove_info': '拒絕理由'
+        'state': '處理中',
+        'arranges': [],
+        'disapprove_info': ''
       },
       dialogTitle: ['在這裡，你可以看到對呱吉來說最重要的事情⋯⋯', '事情好多⋯⋯，但是我還是會努力做完的！'],
       columns: ['id', 'type', 'create_time', 'title', 'state'],
@@ -197,6 +184,7 @@ export default {
         .get('/api/cases/' + caseId)
         .then((response) => {
           this.selectedCaseDetails = response.data
+          // this.selectedCaseDetails = this.selectedCaseDetails
           return true
         })
         .then(() => {

--- a/frontend/src/views/CaseListPage.vue
+++ b/frontend/src/views/CaseListPage.vue
@@ -68,7 +68,6 @@ table
     margin-bottom: 100px
     &::-webkit-scrollbar
       width: 0 !important
-    // height: 80%
 
 .VueTables__search-field
   color: $color_white
@@ -124,8 +123,6 @@ nav
   width: 100%
   color: $color_white
 
-// dialog-content
-
 .el-dialog
   width: 60% !important
   max-height: 50%
@@ -148,37 +145,14 @@ nav
     display: none
 
 .el-dialog__header
-  // background: linear-gradient(#004BE0, #9eaeca 0.05, #004BE0 0.1)
-  // background-color: #787ce4
   background-image: linear-gradient(to right, #63B8B7, #3FA8BC, #5676AC, #7F5596, #BB4577)
-  // padding-top: 30px !important
   border-radius: 5px 5px 0 0
-  // .el-dialog__title
-  //   &:before
-  //     background-image: url('https://storage.googleapis.com/froggy-service/frontend/images/cases/disk_icon.png')
-  //     background-size: auto 100%
-  //     background-repeat: no-repeat
-  //     position: absolute
-  //     width: 200px
-  //     height: 20px
-  //     top: 15px
-  //     left: 12px
-  //     font-size: 12px
-  //     color: $color_white
-  //     content: "\00a0\00a0\00a0\00a0\00a0\00a0 C:\\邱威傑議員研究室"
 
   .el-dialog__headerbtn
-    // top: 10px
     top: 0px
     right: 8px
   .el-icon-close
-    // border: white 1px solid
-    // border-radius: 3px
-    // background-color: #DC4C2C
-    // background-color: $color_white
     color: white !important
-    // width: 20px
-    // height: 20px
     &:before
       vertical-align: -15%
       font-weight: 700
@@ -203,30 +177,27 @@ nav
   box-sizing: border-box !important
   border-width: 5px 5px 0px 5px
   padding: 0 !important
-  // border-style: solid
-  // border-color: #004BE0
-  // border-color: #787ce4
-  // background-color: #EEECE0
   background-color: $color_white
   .case-content
     padding: 20px 20px 5px 20px !important
     max-height: 50vh !important
     overflow: scroll
+    white-space: pre-line
     &::-webkit-scrollbar
       width: 0 !important
     .case-content-title, .case-content-date, .case-content-location, .case-content-details, .arranges-title
       font-size: $fz_sub_header_small
       font-weight: 700
       margin-top: 5px
-    // .case-content-date
-    //   font-size: $fz_p_small
-    //   font-weight: normal
+
 .case-disapproved
   font-size: $fz_p
   font-weight: bold
 .disapprove-info
-  font-size: $fz_p_small
   font-weight: normal
+
+.arrange-content
+  white-space: normal
 
 .arrange-content>p>img, .arrange-content img
   width: 50% !important
@@ -241,12 +212,7 @@ nav
   align-items: center
   display: flex !important
   box-sizing: border-box !important
-  // border-width: 0px 5px 5px 5px
-  // border-style: solid
   border-radius: 0px 0px 5px 5px
-  // border-color: #004BE0
-  // border-color: #787ce4
-  // background-color: #EEECE0
   background-color: $color_white
   padding: 5px 10px 10px 10px !important
   @media screen and (max-width: $break_small)


### PR DESCRIPTION
- CSS 加上 `white-space: pre-line` 讓 `\r\n` 顯示為換行符號 [ref](https://developer.mozilla.org/zh-CN/docs/Web/CSS/white-space)
- 不顯示沒有資訊內容的標題，如尚未回覆進度的處理中案件
- 修正字體大小
- 移除用不到的 CSS